### PR TITLE
Add support for NonNullExpression

### DIFF
--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -97,7 +97,7 @@ function clean(original, cloned, parent) {
     original.type === "JSXElement" &&
     original.openingElement.name.name === "style" &&
     original.openingElement.attributes.some(
-      (attr) => attr.type === "JSXAttribute" && attr.name.name === "jsx",
+      (attr) => attr.type === "JSXAttribute" && attr.name.name === "jsx"
     )
   ) {
     for (const { type, expression } of cloned.children) {
@@ -128,7 +128,7 @@ function clean(original, cloned, parent) {
   ) {
     cloned.value.value = original.value.value.replaceAll(
       /["']|&quot;|&apos;/g,
-      '"',
+      '"'
     );
   }
 
@@ -185,8 +185,8 @@ function clean(original, cloned, parent) {
       (comment) =>
         isBlockComment(comment) &&
         ["GraphQL", "HTML"].some(
-          (languageName) => comment.value === ` ${languageName} `,
-        ),
+          (languageName) => comment.value === ` ${languageName} `
+        )
     );
     if (
       hasLanguageComment ||
@@ -207,6 +207,17 @@ function clean(original, cloned, parent) {
     // Ideally, we should swap these two nodes, but `type` is the only difference
     cloned.type = "TSNonNullExpression";
     cloned.expression.type = "ChainExpression";
+  }
+
+  if (
+    original.type === "ChainExpression" &&
+    original.expression.type === "NonNullExpression"
+  ) {
+    cloned.type = "NonNullExpression";
+    cloned.argument = cloned.expression;
+    cloned.chain = cloned.argument.chain;
+    cloned.argument.type = "ChainExpression";
+    cloned.argument.expression = cloned.argument.argument;
   }
 }
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -65,13 +65,13 @@ function needsParens(path, options) {
     // `for ((let.a) of []);`
     if (node.name === "let") {
       const expression = path.findAncestor(
-        (node) => node.type === "ForOfStatement",
+        (node) => node.type === "ForOfStatement"
       )?.left;
       if (
         expression &&
         startsWithNoLookaheadToken(
           expression,
-          (leftmostNode) => leftmostNode === node,
+          (leftmostNode) => leftmostNode === node
         )
       ) {
         return true;
@@ -90,20 +90,20 @@ function needsParens(path, options) {
         (node) =>
           node.type === "ExpressionStatement" ||
           node.type === "ForStatement" ||
-          node.type === "ForInStatement",
+          node.type === "ForInStatement"
       );
       const expression = !statement
         ? undefined
         : statement.type === "ExpressionStatement"
-          ? statement.expression
-          : statement.type === "ForStatement"
-            ? statement.init
-            : statement.left;
+        ? statement.expression
+        : statement.type === "ForStatement"
+        ? statement.init
+        : statement.left;
       if (
         expression &&
         startsWithNoLookaheadToken(
           expression,
-          (leftmostNode) => leftmostNode === node,
+          (leftmostNode) => leftmostNode === node
         )
       ) {
         return true;
@@ -123,7 +123,7 @@ function needsParens(path, options) {
         case "hook":
         case "type": {
           const ancestorNeitherAsNorSatisfies = path.findAncestor(
-            (node) => !isBinaryCastExpression(node),
+            (node) => !isBinaryCastExpression(node)
           );
           if (
             ancestorNeitherAsNorSatisfies !== parent &&
@@ -145,13 +145,13 @@ function needsParens(path, options) {
     node.type === "DoExpression"
   ) {
     const expression = path.findAncestor(
-      (node) => node.type === "ExpressionStatement",
+      (node) => node.type === "ExpressionStatement"
     )?.expression;
     if (
       expression &&
       startsWithNoLookaheadToken(
         expression,
-        (leftmostNode) => leftmostNode === node,
+        (leftmostNode) => leftmostNode === node
       )
     ) {
       return true;
@@ -160,7 +160,7 @@ function needsParens(path, options) {
 
   if (node.type === "ObjectExpression") {
     const arrowFunctionBody = path.findAncestor(
-      (node) => node.type === "ArrowFunctionExpression",
+      (node) => node.type === "ArrowFunctionExpression"
     )?.body;
     if (
       arrowFunctionBody &&
@@ -168,7 +168,7 @@ function needsParens(path, options) {
       arrowFunctionBody.type !== "AssignmentExpression" &&
       startsWithNoLookaheadToken(
         arrowFunctionBody,
-        (leftmostNode) => leftmostNode === node,
+        (leftmostNode) => leftmostNode === node
       )
     ) {
       return true;
@@ -198,6 +198,7 @@ function needsParens(path, options) {
           node.type === "UpdateExpression" ||
           node.type === "YieldExpression" ||
           node.type === "TSNonNullExpression" ||
+          node.type === "NonNullExpression" ||
           (node.type === "ClassExpression" && isNonEmptyArray(node.decorators)))
       ) {
         return true;
@@ -259,7 +260,7 @@ function needsParens(path, options) {
           undefined,
           undefined,
           (node, key) =>
-            key === "returnType" && node.type === "ArrowFunctionExpression",
+            key === "returnType" && node.type === "ArrowFunctionExpression"
         ) &&
         includesFunctionTypeInObjectType(node)
       ) {
@@ -317,6 +318,7 @@ function needsParens(path, options) {
         case "BinaryExpression":
           return key === "left" && parent.operator === "**";
 
+        case "NonNullExpression":
         case "TSNonNullExpression":
           return true;
 
@@ -384,6 +386,7 @@ function needsParens(path, options) {
         case "SpreadElement":
         case "BindExpression":
         case "AwaitExpression":
+        case "NonNullExpression":
         case "TSNonNullExpression":
         case "UpdateExpression":
           return true;
@@ -487,6 +490,7 @@ function needsParens(path, options) {
         case "TSAsExpression":
         case "TSSatisfiesExpression":
         case "TSNonNullExpression":
+        case "NonNullExpression":
         case "AsExpression":
         case "AsConstExpression":
         case "SatisfiesExpression":
@@ -523,7 +527,7 @@ function needsParens(path, options) {
           (node, key) =>
             key === "typeAnnotation" && node.type === "TSTypeAnnotation",
           (node, key) =>
-            key === "returnType" && node.type === "ArrowFunctionExpression",
+            key === "returnType" && node.type === "ArrowFunctionExpression"
         )
       ) {
         return true;
@@ -658,7 +662,7 @@ function needsParens(path, options) {
           (node, key) =>
             key === "typeAnnotation" && node.type === "TypeAnnotation",
           (node, key) =>
-            key === "returnType" && node.type === "ArrowFunctionExpression",
+            key === "returnType" && node.type === "ArrowFunctionExpression"
         )
       ) {
         return true;
@@ -679,7 +683,7 @@ function needsParens(path, options) {
           (node, key) =>
             key === "typeAnnotation" && node.type === "TypeAnnotation",
           (node, key) =>
-            key === "returnType" && node.type === "ArrowFunctionExpression",
+            key === "returnType" && node.type === "ArrowFunctionExpression"
         )
       ) {
         return true;
@@ -708,7 +712,7 @@ function needsParens(path, options) {
         (parent.type === "FunctionTypeParam" &&
           parent.name === null &&
           getFunctionParameters(node).some(
-            (param) => param.typeAnnotation?.type === "NullableTypeAnnotation",
+            (param) => param.typeAnnotation?.type === "NullableTypeAnnotation"
           ))
       );
     }
@@ -829,6 +833,7 @@ function needsParens(path, options) {
         case "AsExpression":
         case "AsConstExpression":
         case "SatisfiesExpression":
+        case "NonNullExpression":
         case "TSNonNullExpression":
           return true;
 
@@ -884,6 +889,7 @@ function needsParens(path, options) {
         case "AsExpression":
         case "AsConstExpression":
         case "SatisfiesExpression":
+        case "NonNullExpression":
         case "TSNonNullExpression":
         case "BindExpression":
         case "TaggedTemplateExpression":
@@ -918,6 +924,7 @@ function needsParens(path, options) {
 
     // fallthrough
     case "TaggedTemplateExpression":
+    case "NonNullExpression":
     case "TSNonNullExpression":
       if (
         key === "callee" &&
@@ -938,6 +945,9 @@ function needsParens(path, options) {
             // see https://tc39.github.io/ecma262/#prod-MemberExpression
             case "TaggedTemplateExpression":
               object = object.tag;
+              break;
+            case "NonNullExpression":
+              object = object.argument;
               break;
             case "TSNonNullExpression":
               object = object.expression;
@@ -1087,7 +1097,7 @@ function includesFunctionTypeInObjectType(node) {
     node,
     (node) =>
       node.type === "ObjectTypeAnnotation" &&
-      hasNode(node, (node) => node.type === "FunctionTypeAnnotation"),
+      hasNode(node, (node) => node.type === "FunctionTypeAnnotation")
   );
 }
 
@@ -1150,7 +1160,7 @@ function shouldWrapFunctionForExportDefault(path, options) {
 
   return path.call(
     () => shouldWrapFunctionForExportDefault(path, options),
-    ...getLeftSidePathName(node),
+    ...getLeftSidePathName(node)
   );
 }
 
@@ -1182,7 +1192,8 @@ function shouldAddParenthesesToChainElement(path) {
       (key === "callee" &&
         (parent.type === "CallExpression" ||
           parent.type === "NewExpression")) ||
-      (parent.type === "TSNonNullExpression" &&
+      ((parent.type === "TSNonNullExpression" ||
+        (parent.type === "NonNullExpression" && !parent.chain)) &&
         grandparent.type === "MemberExpression" &&
         grandparent.object === parent))
   ) {
@@ -1193,7 +1204,7 @@ function shouldAddParenthesesToChainElement(path) {
   if (
     path.match(
       () => node.type === "CallExpression" || node.type === "MemberExpression",
-      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "expression" && node.type === "ChainExpression"
     ) &&
     (path.match(
       undefined,
@@ -1204,14 +1215,21 @@ function shouldAddParenthesesToChainElement(path) {
             node.type === "NewExpression")) ||
         (name === "object" &&
           node.type === "MemberExpression" &&
-          !node.optional),
+          !node.optional)
     ) ||
       path.match(
         undefined,
         undefined,
         (node, name) =>
           name === "expression" && node.type === "TSNonNullExpression",
-        (node, name) => name === "object" && node.type === "MemberExpression",
+        (node, name) => name === "object" && node.type === "MemberExpression"
+      ) ||
+      path.match(
+        undefined,
+        undefined,
+        (node, name) =>
+          name === "argument" && node.type === "NonNullExpression",
+        (node, name) => name === "object" && node.type === "MemberExpression"
       ))
   ) {
     return true;
@@ -1225,7 +1243,13 @@ function shouldAddParenthesesToChainElement(path) {
       (node, name) =>
         name === "expression" && node.type === "TSNonNullExpression",
       (node, name) => name === "expression" && node.type === "ChainExpression",
-      (node, name) => name === "object" && node.type === "MemberExpression",
+      (node, name) => name === "object" && node.type === "MemberExpression"
+    ) ||
+    path.match(
+      () => node.type === "CallExpression" || node.type === "MemberExpression",
+      (node, name) => name === "argument" && node.type === "NonNullExpression",
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "object" && node.type === "MemberExpression"
     )
   ) {
     return true;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -1183,19 +1183,99 @@ new (a?.())();
 ```
 */
 function shouldAddParenthesesToChainElement(path) {
-  // Babel, this was implemented before #13735, can use `path.match` as estree does
-  const { node, parent, grandparent, key } = path;
   if (
-    (node.type === "OptionalMemberExpression" ||
-      node.type === "OptionalCallExpression") &&
-    ((key === "object" && parent.type === "MemberExpression") ||
-      (key === "callee" &&
-        (parent.type === "CallExpression" ||
-          parent.type === "NewExpression")) ||
-      ((parent.type === "TSNonNullExpression" ||
-        (parent.type === "NonNullExpression" && !parent.chain)) &&
-        grandparent.type === "MemberExpression" &&
-        grandparent.object === parent))
+    // ESTree
+    path.match(
+      undefined,
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    // Babel
+    path.match(
+      (node) =>
+        node.type === "OptionalCallExpression" ||
+        node.type === "OptionalMemberExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    // Babel-ts
+    // (a?.b)!``;
+    // (a?.b!)``;
+    path.match(
+      (node) =>
+        node.type === "OptionalCallExpression" ||
+        node.type === "OptionalMemberExpression",
+      (node, name) =>
+        name === "expression" && node.type === "TSNonNullExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    path.match(
+      (node) =>
+        node.type === "OptionalCallExpression" ||
+        node.type === "OptionalMemberExpression",
+      (node, name) => name === "argument" && node.type === "NonNullExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    // case (a?.b)!``; in Typescript
+    path.match(
+      undefined,
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) =>
+        name === "expression" && node.type === "TSNonNullExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    path.match(
+      undefined,
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "argument" && node.type === "NonNullExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    // case (a?.b!)``; in Typescript
+    path.match(
+      undefined,
+      (node, name) =>
+        name === "expression" && node.type === "TSNonNullExpression",
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    ) ||
+    path.match(
+      undefined,
+      (node, name) => name === "argument" && node.type === "NonNullExpression",
+      (node, name) => name === "expression" && node.type === "ChainExpression",
+      (node, name) => name === "tag" && node.type === "TaggedTemplateExpression"
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    path.match(
+      (node) =>
+        node.type === "OptionalMemberExpression" ||
+        node.type === "OptionalCallExpression",
+      (node, name) =>
+        (name === "object" && node.type === "MemberExpression") ||
+        (name === "callee" &&
+          (node.type === "CallExpression" || node.type === "NewExpression"))
+    ) ||
+    path.match(
+      (node) =>
+        node.type === "OptionalMemberExpression" ||
+        node.type === "OptionalCallExpression",
+      (node, name) =>
+        name === "expression" && node.type === "TSNonNullExpression",
+      (node, name) =>
+        (name === "object" && node.type === "MemberExpression") ||
+        (name === "callee" && node.type === "CallExpression")
+    ) ||
+    path.match(
+      (node) =>
+        node.type === "OptionalMemberExpression" ||
+        node.type === "OptionalCallExpression",
+      (node, name) => name === "argument" && node.type === "NonNullExpression",
+      (node, name) =>
+        (name === "object" && node.type === "MemberExpression") ||
+        (name === "callee" && node.type === "CallExpression")
+    )
   ) {
     return true;
   }
@@ -1203,7 +1283,8 @@ function shouldAddParenthesesToChainElement(path) {
   // ESTree, same logic as babel
   if (
     path.match(
-      () => node.type === "CallExpression" || node.type === "MemberExpression",
+      (node) =>
+        node.type === "CallExpression" || node.type === "MemberExpression",
       (node, name) => name === "expression" && node.type === "ChainExpression"
     ) &&
     (path.match(
@@ -1222,14 +1303,18 @@ function shouldAddParenthesesToChainElement(path) {
         undefined,
         (node, name) =>
           name === "expression" && node.type === "TSNonNullExpression",
-        (node, name) => name === "object" && node.type === "MemberExpression"
+        (node, name) =>
+          (name === "object" && node.type === "MemberExpression") ||
+          (name === "callee" && node.type === "CallExpression")
       ) ||
       path.match(
         undefined,
         undefined,
         (node, name) =>
           name === "argument" && node.type === "NonNullExpression",
-        (node, name) => name === "object" && node.type === "MemberExpression"
+        (node, name) =>
+          (name === "object" && node.type === "MemberExpression") ||
+          (name === "callee" && node.type === "CallExpression")
       ))
   ) {
     return true;
@@ -1239,17 +1324,23 @@ function shouldAddParenthesesToChainElement(path) {
   // Use this to align with babel
   if (
     path.match(
-      () => node.type === "CallExpression" || node.type === "MemberExpression",
+      (node) =>
+        node.type === "CallExpression" || node.type === "MemberExpression",
       (node, name) =>
         name === "expression" && node.type === "TSNonNullExpression",
       (node, name) => name === "expression" && node.type === "ChainExpression",
-      (node, name) => name === "object" && node.type === "MemberExpression"
+      (node, name) =>
+        (name === "object" && node.type === "MemberExpression") ||
+        (name === "callee" && node.type === "CallExpression")
     ) ||
     path.match(
-      () => node.type === "CallExpression" || node.type === "MemberExpression",
+      (node) =>
+        node.type === "CallExpression" || node.type === "MemberExpression",
       (node, name) => name === "argument" && node.type === "NonNullExpression",
       (node, name) => name === "expression" && node.type === "ChainExpression",
-      (node, name) => name === "object" && node.type === "MemberExpression"
+      (node, name) =>
+        (name === "object" && node.type === "MemberExpression") ||
+        (name === "callee" && node.type === "CallExpression")
     )
   ) {
     return true;

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -35,7 +35,7 @@ function printAssignment(
   print,
   leftDoc,
   operator,
-  rightPropertyName,
+  rightPropertyName
 ) {
   const layout = chooseLayout(path, options, print, leftDoc, rightPropertyName);
 
@@ -91,7 +91,7 @@ function printAssignmentExpression(path, options, print) {
     print,
     print("left"),
     [" ", node.operator],
-    "right",
+    "right"
   );
 }
 
@@ -118,15 +118,15 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
     (node) =>
       !isTail ||
       (node.type !== "ExpressionStatement" &&
-        node.type !== "VariableDeclaration"),
+        node.type !== "VariableDeclaration")
   );
   if (shouldUseChainFormatting) {
     return !isTail
       ? "chain"
       : rightNode.type === "ArrowFunctionExpression" &&
-          rightNode.body.type === "ArrowFunctionExpression"
-        ? "chain-tail-arrow-chain"
-        : "chain-tail";
+        rightNode.body.type === "ArrowFunctionExpression"
+      ? "chain-tail-arrow-chain"
+      : "chain-tail";
   }
   const isHeadOfLongChain = !isTail && isAssignment(rightNode.right);
 
@@ -164,7 +164,7 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
   if (
     path.call(
       () => shouldBreakAfterOperator(path, options, print, hasShortKey),
-      rightPropertyName,
+      rightPropertyName
     )
   ) {
     return "break-after-operator";
@@ -232,6 +232,7 @@ function shouldBreakAfterOperator(path, options, print, hasShortKey) {
   const propertiesForPath = [];
   for (;;) {
     if (
+      node.type === "NonNullExpression" ||
       node.type === "UnaryExpression" ||
       node.type === "AwaitExpression" ||
       (node.type === "YieldExpression" && node.argument !== null)
@@ -249,7 +250,7 @@ function shouldBreakAfterOperator(path, options, print, hasShortKey) {
     isStringLiteral(node) ||
     path.call(
       () => isPoorlyBreakableMemberOrCallChain(path, options, print),
-      ...propertiesForPath,
+      ...propertiesForPath
     )
   ) {
     return true;
@@ -269,7 +270,7 @@ function isComplexDestructuring(node) {
       leftNode.properties.some(
         (property) =>
           isObjectProperty(property) &&
-          (!property.shorthand || property.value?.type === "AssignmentPattern"),
+          (!property.shorthand || property.value?.type === "AssignmentPattern")
       )
     );
   }
@@ -318,7 +319,7 @@ function hasComplexTypeAnnotation(node) {
     return false;
   }
   const typeParams = getTypeParametersFromTypeReference(
-    typeAnnotation.typeAnnotation,
+    typeAnnotation.typeAnnotation
   );
   return (
     isNonEmptyArray(typeParams) &&
@@ -326,7 +327,7 @@ function hasComplexTypeAnnotation(node) {
     typeParams.some(
       (param) =>
         isNonEmptyArray(getTypeParametersFromTypeReference(param)) ||
-        param.type === "TSConditionalType",
+        param.type === "TSConditionalType"
     )
   );
 }
@@ -356,7 +357,7 @@ function isPoorlyBreakableMemberOrCallChain(
   path,
   options,
   print,
-  deep = false,
+  deep = false
 ) {
   const { node } = path;
   const goDeeper = () =>
@@ -364,6 +365,10 @@ function isPoorlyBreakableMemberOrCallChain(
 
   if (node.type === "ChainExpression" || node.type === "TSNonNullExpression") {
     return path.call(goDeeper, "expression");
+  }
+
+  if (node.type === "NonNullExpression") {
+    return path.call(goDeeper, "argument");
   }
 
   if (isCallExpression(node)) {

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -150,8 +150,8 @@ function printEstree(path, options, print, args) {
 
       parts.push(
         group(
-          indent([softline, printBindExpressionCallee(path, options, print)]),
-        ),
+          indent([softline, printBindExpressionCallee(path, options, print)])
+        )
       );
 
       return parts;
@@ -199,13 +199,13 @@ function printEstree(path, options, print, args) {
           // avoid printing `await (await` on one line
           const parentAwaitOrBlock = path.findAncestor(
             (node) =>
-              node.type === "AwaitExpression" || node.type === "BlockStatement",
+              node.type === "AwaitExpression" || node.type === "BlockStatement"
           );
           if (
             parentAwaitOrBlock?.type !== "AwaitExpression" ||
             !startsWithNoLookaheadToken(
               parentAwaitOrBlock.argument,
-              (leftmostNode) => leftmostNode === node,
+              (leftmostNode) => leftmostNode === node
             )
           ) {
             return group(parts);
@@ -305,7 +305,7 @@ function printEstree(path, options, print, args) {
 
       if (hasComment(node.argument)) {
         parts.push(
-          group(["(", indent([softline, print("argument")]), softline, ")"]),
+          group(["(", indent([softline, print("argument")]), softline, ")"])
         );
       } else {
         parts.push(print("argument"));
@@ -353,7 +353,7 @@ function printEstree(path, options, print, args) {
               ",",
               hasValue && !isParentForLoop ? hardline : line,
               p,
-            ]),
+            ])
         ),
       ];
 
@@ -385,7 +385,7 @@ function printEstree(path, options, print, args) {
         const commentOnOwnLine =
           hasComment(
             node.consequent,
-            CommentCheckFlags.Trailing | CommentCheckFlags.Line,
+            CommentCheckFlags.Trailing | CommentCheckFlags.Line
           ) || needsHardlineAfterDanglingComment(node);
         const elseOnSameLine =
           node.consequent.type === "BlockStatement" && !commentOnOwnLine;
@@ -394,7 +394,7 @@ function printEstree(path, options, print, args) {
         if (hasComment(node, CommentCheckFlags.Dangling)) {
           parts.push(
             printDanglingComments(path, options),
-            commentOnOwnLine ? hardline : " ",
+            commentOnOwnLine ? hardline : " "
           );
         }
 
@@ -404,9 +404,9 @@ function printEstree(path, options, print, args) {
             adjustClause(
               node.alternate,
               print("alternate"),
-              node.alternate.type === "IfStatement",
-            ),
-          ),
+              node.alternate.type === "IfStatement"
+            )
+          )
         );
       }
 
@@ -490,7 +490,7 @@ function printEstree(path, options, print, args) {
         "while (",
         group([indent([softline, print("test")]), softline]),
         ")",
-        semi,
+        semi
       );
 
       return parts;
@@ -532,7 +532,7 @@ function printEstree(path, options, print, args) {
             (comment.trailing &&
               hasNewline(options.originalText, locStart(comment), {
                 backwards: true,
-              })),
+              }))
         );
         const param = print("param");
 
@@ -566,8 +566,8 @@ function printEstree(path, options, print, args) {
                     print(),
                     !isLast && isNextLineEmpty(node, options) ? hardline : "",
                   ],
-                  "cases",
-                ),
+                  "cases"
+                )
               ),
             ])
           : "",
@@ -586,7 +586,7 @@ function printEstree(path, options, print, args) {
       }
 
       const consequent = node.consequent.filter(
-        (node) => node.type !== "EmptyStatement",
+        (node) => node.type !== "EmptyStatement"
       );
 
       if (consequent.length > 0) {
@@ -595,7 +595,7 @@ function printEstree(path, options, print, args) {
         parts.push(
           consequent.length === 1 && consequent[0].type === "BlockStatement"
             ? [" ", cons]
-            : indent([hardline, cons]),
+            : indent([hardline, cons])
         );
       }
 
@@ -628,6 +628,8 @@ function printEstree(path, options, print, args) {
       return ["#", node.name];
     case "PrivateName":
       return ["#", print("id")];
+    case "NonNullExpression":
+      return [print("argument"), "!"];
 
     // For hack-style pipeline
     case "TopicReference":

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -54,7 +54,7 @@ function printMemberChain(path, options, print) {
   if (path.node.type === "ChainExpression") {
     return path.call(
       () => printMemberChain(path, options, print),
-      "expression",
+      "expression"
     );
   }
 
@@ -78,7 +78,7 @@ function printMemberChain(path, options, print) {
     const { originalText } = options;
     const nextCharIndex = getNextNonSpaceNonCommentCharacterIndex(
       originalText,
-      locEnd(node),
+      locEnd(node)
     );
     const nextChar = originalText.charAt(nextCharIndex);
 
@@ -117,7 +117,7 @@ function printMemberChain(path, options, print) {
               printFunctionTypeParameters(path, options, print),
               printCallArguments(path, options, print),
             ],
-            options,
+            options
           ),
           hasTrailingEmptyLine ? hardline : "",
         ],
@@ -132,7 +132,7 @@ function printMemberChain(path, options, print) {
           isMemberExpression(node)
             ? printMemberLookup(path, options, print)
             : printBindExpressionCallee(path, options, print),
-          options,
+          options
         ),
       });
       path.call((object) => rec(object), "object");
@@ -142,6 +142,12 @@ function printMemberChain(path, options, print) {
         printed: printComments(path, "!", options),
       });
       path.call((expression) => rec(expression), "expression");
+    } else if (node.type === "NonNullExpression") {
+      printedNodes.unshift({
+        node,
+        printed: printComments(path, "!", options),
+      });
+      path.call((argument) => rec(argument), "argument");
     } else {
       printedNodes.unshift({
         node,
@@ -197,6 +203,7 @@ function printMemberChain(path, options, print) {
   for (; i < printedNodes.length; ++i) {
     if (
       printedNodes[i].node.type === "TSNonNullExpression" ||
+      printedNodes[i].node.type === "NonNullExpression" ||
       isCallExpression(printedNodes[i].node) ||
       (isMemberExpression(printedNodes[i].node) &&
         printedNodes[i].node.computed &&
@@ -405,7 +412,7 @@ function printMemberChain(path, options, print) {
     nodeHasComment ||
     (callExpressions.length > 2 &&
       callExpressions.some(
-        (expr) => !expr.arguments.every((arg) => isSimpleCallArgument(arg)),
+        (expr) => !expr.arguments.every((arg) => isSimpleCallArgument(arg))
       )) ||
     printedGroups.slice(0, -1).some(willBreak) ||
     lastGroupWillBreakAndOtherCallsHaveFunctionArguments()

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -11,6 +11,9 @@ const isCallExpressionWithArguments = (node) => {
   if (node.type === "ChainExpression" || node.type === "TSNonNullExpression") {
     node = node.expression;
   }
+  if (node.type === "NonNullExpression") {
+    node = node.argument;
+  }
   return isCallExpression(node) && getCallArguments(node).length > 0;
 };
 
@@ -20,11 +23,19 @@ function printMemberExpression(path, options, print) {
   const { node } = path;
   const firstNonMemberParent = path.findAncestor(
     (node) =>
-      !(isMemberExpression(node) || node.type === "TSNonNullExpression"),
+      !(
+        isMemberExpression(node) ||
+        node.type === "TSNonNullExpression" ||
+        node.type === "NonNullExpression"
+      )
   );
   const firstNonChainElementWrapperParent = path.findAncestor(
     (node) =>
-      !(node.type === "ChainExpression" || node.type === "TSNonNullExpression"),
+      !(
+        node.type === "ChainExpression" ||
+        node.type === "TSNonNullExpression" ||
+        (node.type === "NonNullExpression" && node.chain)
+      )
   );
 
   const shouldInline =

--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -154,7 +154,8 @@ function shouldExtraIndentForConditionalExpression(path) {
       (node.type === "ChainExpression" && node.expression === child) ||
       (isCallExpression(node) && node.callee === child) ||
       (isMemberExpression(node) && node.object === child) ||
-      (node.type === "TSNonNullExpression" && node.expression === child)
+      (node.type === "TSNonNullExpression" && node.expression === child) ||
+      (node.type === "NonNullExpression" && node.argument === child)
     ) {
       child = node;
       continue;
@@ -229,7 +230,7 @@ function printTernaryOld(path, options, print) {
     currentParent &&
     currentParent.type === node.type &&
     testNodePropertyNames.every(
-      (prop) => currentParent[prop] !== previousParent,
+      (prop) => currentParent[prop] !== previousParent
     )
   );
   const firstNonConditionalParent = currentParent || parent;
@@ -272,13 +273,13 @@ function printTernaryOld(path, options, print) {
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
         ? print(alternateNodePropertyName)
-        : wrap(print(alternateNodePropertyName)),
+        : wrap(print(alternateNodePropertyName))
     );
   } else {
     /*
     This does not mean to indent, but make the doc aligned with the first character after `? ` or `: `,
     so we use `2` instead of `options.tabWidth` here.
-    
+
     ```js
     test
      ? {
@@ -288,7 +289,7 @@ function printTernaryOld(path, options, print) {
     ```
 
     instead of
-    
+
     ```js
     test
      ? {
@@ -318,8 +319,8 @@ function printTernaryOld(path, options, print) {
         isParentTest
         ? part
         : options.useTabs
-          ? dedent(indent(part))
-          : align(Math.max(0, options.tabWidth - 2), part),
+        ? dedent(indent(part))
+        : align(Math.max(0, options.tabWidth - 2), part)
     );
   }
 
@@ -338,16 +339,16 @@ function printTernaryOld(path, options, print) {
         hasNewlineInRange(
           options.originalText,
           locStart(comment),
-          locEnd(comment),
-        ),
-    ),
+          locEnd(comment)
+        )
+    )
   );
   const maybeGroup = (doc) =>
     parent === firstNonConditionalParent
       ? group(doc, { shouldBreak })
       : shouldBreak
-        ? [doc, breakParent]
-        : doc;
+      ? [doc, breakParent]
+      : doc;
 
   // Break the closing paren to keep the chain right after it:
   // (a

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -50,7 +50,7 @@ function hasMultilineBlockComments(
   testNodes,
   consequentNode,
   alternateNode,
-  options,
+  options
 ) {
   const comments = [
     ...testNodes.map((node) => getComments(node)),
@@ -63,8 +63,8 @@ function hasMultilineBlockComments(
       hasNewlineInRange(
         options.originalText,
         locStart(comment),
-        locEnd(comment),
-      ),
+        locEnd(comment)
+      )
   );
 }
 
@@ -104,7 +104,8 @@ function shouldExtraIndentForConditionalExpression(path) {
       (node.type === "ChainExpression" && node.expression === child) ||
       (isCallExpression(node) && node.callee === child) ||
       (isMemberExpression(node) && node.object === child) ||
-      (node.type === "TSNonNullExpression" && node.expression === child)
+      (node.type === "TSNonNullExpression" && node.expression === child) ||
+      (node.type === "NonNullExpression" && node.argument === child)
     ) {
       child = node;
       continue;
@@ -194,7 +195,7 @@ function printTernary(path, options, print, args) {
     currentParent &&
     currentParent.type === node.type &&
     testNodePropertyNames.every(
-      (prop) => currentParent[prop] !== previousParent,
+      (prop) => currentParent[prop] !== previousParent
     )
   );
   const firstNonConditionalParent = currentParent || parent;
@@ -227,8 +228,8 @@ function printTernary(path, options, print, args) {
   const fillTab = !isBigTabs
     ? ""
     : options.useTabs
-      ? "\t"
-      : " ".repeat(options.tabWidth - 1);
+    ? "\t"
+    : " ".repeat(options.tabWidth - 1);
 
   // We want a whole chain of ConditionalExpressions to all
   // break if any of them break. That means we should only group around the
@@ -238,7 +239,7 @@ function printTernary(path, options, print, args) {
       testNodes,
       consequentNode,
       alternateNode,
-      options,
+      options
     ) ||
     isConsequentTernary ||
     isAlternateTernary;
@@ -286,7 +287,7 @@ function printTernary(path, options, print, args) {
     path.call((childPath) => {
       consequentComments.push(
         printDanglingComments(childPath, options),
-        hardline,
+        hardline
       );
     }, "consequent");
   }
@@ -354,7 +355,7 @@ function printTernary(path, options, print, args) {
                 groupId: testId,
               }),
         ],
-        { id: testAndConsequentId },
+        { id: testAndConsequentId }
       )
     : [printedTestWithQuestionMark, consequent];
 
@@ -371,27 +372,24 @@ function printTernary(path, options, print, args) {
     alternateComments.length > 0
       ? [indent([hardline, alternateComments]), hardline]
       : isAlternateTernary
-        ? hardline
-        : tryToParenthesizeAlternate
-          ? ifBreak(line, " ", { groupId: testAndConsequentId })
-          : line,
+      ? hardline
+      : tryToParenthesizeAlternate
+      ? ifBreak(line, " ", { groupId: testAndConsequentId })
+      : line,
 
     ":",
 
     isAlternateTernary
       ? " "
       : !isBigTabs
-        ? " "
-        : shouldGroupTestAndConsequent
-          ? ifBreak(
-              fillTab,
-              ifBreak(
-                isInChain || tryToParenthesizeAlternate ? " " : fillTab,
-                " ",
-              ),
-              { groupId: testAndConsequentId },
-            )
-          : ifBreak(fillTab, " "),
+      ? " "
+      : shouldGroupTestAndConsequent
+      ? ifBreak(
+          fillTab,
+          ifBreak(isInChain || tryToParenthesizeAlternate ? " " : fillTab, " "),
+          { groupId: testAndConsequentId }
+        )
+      : ifBreak(fillTab, " "),
 
     isAlternateTernary
       ? printedAlternateWithParens
@@ -415,15 +413,12 @@ function printTernary(path, options, print, args) {
         // which I'm ambivalent about but some people like keeping on the same line as the assignment.
         group(indent([softline, group(parts)]))
       : isOnSameLineAsAssignment || isOnSameLineAsReturn
-        ? group(indent(parts))
-        : shouldExtraIndent || (isTSConditional && isInTest)
-          ? group([
-              indent([softline, parts]),
-              breakTSClosingParen ? softline : "",
-            ])
-          : parent === firstNonConditionalParent
-            ? group(parts)
-            : parts;
+      ? group(indent(parts))
+      : shouldExtraIndent || (isTSConditional && isInTest)
+      ? group([indent([softline, parts]), breakTSClosingParen ? softline : ""])
+      : parent === firstNonConditionalParent
+      ? group(parts)
+      : parts;
 
   return result;
 }

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -44,6 +44,7 @@ const additionalVisitorKeys = {
   AsExpression: ["expression", "typeAnnotation"],
   AsConstExpression: ["expression"],
   SatisfiesExpression: ["expression", "typeAnnotation"],
+  NonNullExpression: ["argument"],
   TypeofTypeAnnotation: ["argument", "typeArguments"],
 };
 
@@ -76,13 +77,13 @@ const visitorKeys = Object.fromEntries(
       flowVisitorKeys,
       angularVisitorKeys,
       additionalVisitorKeys,
-    ]),
+    ])
   ).map(([type, keys]) => [
     type,
     excludeKeys[type]
       ? keys.filter((key) => !excludeKeys[type].includes(key))
       : keys,
-  ]),
+  ])
 );
 
 export default visitorKeys;


### PR DESCRIPTION
## Description

Adds support for the postfix ! operator (e.g. `a!.b!`). For the most part, this implementation directly parallels the existing support for TSNonNullExpression; the only more significant change is for the needsParens logic, where I've pulled in the logic from upstream--there seems to have been a bug in the previous support for TSNonNullExpression where (a?.())!.c would be emitted as a?.()!.c, which are not equivalent expressions.