### PR TITLE
Keyof parentheses fix

### DIFF
--- a/changelog_unreleased/flow/pr-keyof-parens.md
+++ b/changelog_unreleased/flow/pr-keyof-parens.md
@@ -1,0 +1,19 @@
+#### Fix parentheses preservation for `keyof` in array and indexed access types (#XXXX by @marcoww)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type T = (keyof Foo)[];
+type T2 = (keyof typeof obj)[];
+type T3 = (keyof Foo)['bar'];
+
+// Prettier stable
+type T = keyof Foo[];
+type T2 = keyof typeof obj[];
+type T3 = keyof Foo['bar'];
+
+// Prettier main
+type T = (keyof Foo)[];
+type T2 = (keyof typeof obj)[];
+type T3 = (keyof Foo)['bar'];
+```

--- a/src/language-js/parentheses/needs-parentheses.js
+++ b/src/language-js/parentheses/needs-parentheses.js
@@ -536,6 +536,13 @@ function needsParentheses(path, options) {
             parent.type === "OptionalIndexedAccessType")) ||
         (key === "elementType" && parent.type === "ArrayTypeAnnotation")
       );
+    case "KeyofTypeAnnotation":
+      return (
+        (key === "objectType" &&
+          (parent.type === "IndexedAccessType" ||
+            parent.type === "OptionalIndexedAccessType")) ||
+        (key === "elementType" && parent.type === "ArrayTypeAnnotation")
+      );
     case "ArrayTypeAnnotation":
       return parent.type === "NullableTypeAnnotation";
 

--- a/tests/format/flow/keyof/format.test.js
+++ b/tests/format/flow/keyof/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["flow"]);

--- a/tests/format/flow/keyof/keyof.js
+++ b/tests/format/flow/keyof/keyof.js
@@ -1,0 +1,29 @@
+// Basic keyof
+type T1 = keyof Foo;
+
+// keyof typeof
+type T2 = keyof typeof obj;
+
+// keyof in array type annotation - needs parens
+type T3 = (keyof Foo)[];
+
+// keyof typeof in array type annotation - needs parens
+type T4 = (keyof typeof obj)[];
+
+// keyof in indexed access type - needs parens
+type T5 = (keyof Foo)['bar'];
+
+// keyof typeof in indexed access type - needs parens
+type T6 = (keyof typeof obj)['bar'];
+
+// keyof with union type
+type T7 = keyof Foo | string;
+
+// keyof with intersection type
+type T8 = keyof Foo & string;
+
+// typeof in array type annotation - needs parens
+type T9 = (typeof obj)[];
+
+// typeof in indexed access type - needs parens
+type T10 = (typeof obj)['bar'];


### PR DESCRIPTION
Summary:  you can't add `export const MODULE_KEYS: (keyof ModuleDefinitions)[] = []`
 because prettier will erase the parenthesis. www does not have this behavior.

Test Plan: CI (couldn't figure out how to run on devserver)

Reviewers: #flow

## Checklist

- [x] I’ve added tests to confirm my change works.
- [n/a] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
