### PR TITLE
cherrypick: Print `async` keyword for component declarations

### DIFF
--- a/changelog_unreleased/flow/19053.md
+++ b/changelog_unreleased/flow/19053.md
@@ -1,0 +1,13 @@
+#### Print `async` keyword for component declarations (#19053 by @mvitousek)
+
+<!-- prettier-ignore -->
+```flow
+// Input
+async component MyAsyncComponent() {}
+
+// Prettier stable
+component MyAsyncComponent() {}
+
+// Prettier main
+async component MyAsyncComponent() {}
+```

--- a/src/language-js/print/component.js
+++ b/src/language-js/print/component.js
@@ -25,7 +25,11 @@ import { printDeclareToken } from "./misc.js";
 function printComponent(path, options, print) {
   const { node } = path;
 
-  const parts = [printDeclareToken(path), "component"];
+  const parts = [
+    printDeclareToken(path),
+    node.async ? "async " : "",
+    "component",
+  ];
   if (node.id) {
     parts.push(" ", print("id"));
   }

--- a/tests/format/flow/component/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/component/__snapshots__/format.test.js.snap
@@ -73,6 +73,16 @@ component MyComponent(
 
 component MyComponent() /* Trailing comment */ {}
 
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}
+
 =====================================output=====================================
 component MyComponent() {}
 
@@ -174,6 +184,16 @@ component MyComponent(
 ) {}
 
 component MyComponent() /* Trailing comment */ {}
+
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}
 
 ================================================================================
 `;

--- a/tests/format/flow/component/component-declaration.js
+++ b/tests/format/flow/component/component-declaration.js
@@ -64,3 +64,13 @@ component MyComponent(
 ) {}
 
 component MyComponent() /* Trailing comment */ {}
+
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}

--- a/tests/format/flow/hook/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/hook/__snapshots__/format.test.js.snap
@@ -161,6 +161,14 @@ hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {};
 
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}
+
 =====================================output=====================================
 hook useFoo1() {}
 
@@ -199,6 +207,14 @@ hook useFoo13(
 hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {}
+
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}
 
 ================================================================================
 `;

--- a/tests/format/flow/hook/hook-declaration.js
+++ b/tests/format/flow/hook/hook-declaration.js
@@ -27,3 +27,11 @@ hook useFoo13(foo: Array<Foooooooooooooooooooooooooooooooooooooooooooooooooooooo
 hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {};
+
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}


### PR DESCRIPTION

## Description

Cherrypick https://github.com/prettier/prettier/pull/19053 to the flow-fork

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
